### PR TITLE
Capture legislature name with correct encoding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,5 +58,8 @@ DEPENDENCIES
   rest-client
   scraperwiki!
 
+RUBY VERSION
+   ruby 2.0.0p648
+
 BUNDLED WITH
-   1.10.6
+   1.13.5

--- a/scraper.rb
+++ b/scraper.rb
@@ -35,7 +35,7 @@ def terms
   @terms ||= noko_q('organizations', where: %Q[{"classification":"chamber"}] ).map do |chamber|
     {
       id: chamber.xpath('.//id').text,
-      name: chamber.xpath('.//name').text.sub('Kuvendit të Kosovës - ',''),
+      name: chamber.xpath('.//value').text.sub('Kuvendit të Kosovës - ',''),
       start_date: chamber.xpath('.//founding_date').text,
       end_date: chamber.xpath('.//dissolution_date').text,
       source: chamber.xpath('.//sources/url').text,


### PR DESCRIPTION
The legislature name was being captured with an ecoding error:
'Periudha e parÃ« Legjislative'

It was noticed that the legislature name was available elsewhere
within the document with the correct encoding.

This is a step towards fixing: https://github.com/everypolitician/everypolitician-data/issues/25276

**Note**: This change does not have an associated regression test because the scraper has not yet been refactored to classes, nor has a test framework been set up for this repo. I have used the scraper output to rebuild the data locally and have seen that the fix works as expected.